### PR TITLE
Fix `Request` and `ReadableStream` overrides

### DIFF
--- a/samples/tcp/config.capnp
+++ b/samples/tcp/config.capnp
@@ -1,0 +1,44 @@
+# This example defines the configuration for a simple Gopher
+# (https://en.wikipedia.org/wiki/Gopher_(protocol)) client, with an optional HTTP proxy
+# configuration as well.
+#
+# The comments in this file focus on TCP-related configuration. For details about the rest check
+# out the helloworld/config.capnp file (also under the samples directory).
+# Also be sure to refer to the comments in /src/workerd/server/workerd.capnp.
+
+using Workerd = import "/workerd/workerd.capnp";
+
+const helloWorldExample :Workerd.Config = (
+
+  # Every workerd instance consists of a set of named services. A worker, for instance,
+  # is a type of service. Here we create a single worker service and an ExternalServer which
+  # defines a local proxy. The configuration details for these are defined below.
+  services = [
+    (name = "main", worker = .gopherWorker),
+    (name = "proxy", external = .localProxy)
+  ],
+
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+# The definition of the actual worker exposed using the "main" service.
+const gopherWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "gopher.js")
+  ],
+  compatibilityDate = "2022-09-26",
+  # In order to access our configured proxy we need to specify it as a binding. This will allow
+  # it to be accessible via `env.proxy` in the JS script.
+  bindings = [
+    (name = "proxy", service = "proxy")
+  ]
+);
+
+# The definition of an external server which in this case is an HTTP proxy. Any connections made
+# through it will be tunneled using HTTP CONNECT.
+const localProxy :Workerd.ExternalServer = (
+  address = "localhost:1234",
+  http = (
+    style = proxy
+  )
+);

--- a/samples/tcp/gopher.js
+++ b/samples/tcp/gopher.js
@@ -1,0 +1,55 @@
+// WARNING: The TCP Sockets API in workerd is still in development, the following sample is likely
+// to change.
+//
+// This is an ESM module implementing a simple Gopher client. Gopher is an old alternative to HTTP,
+// it is also a simple protocol which makes it ideal for demoing TCP sockets in workerd.
+//
+// This module implements both direct and proxied TCP connections. In order to make use of the
+// proxy you'll need to have an HTTP proxy running on port 1234 (this can be changed in config.capnp).
+//
+// Example usage once you have workerd running:
+//
+// - curl localhost:8080/ # Retrieve the main segment in gopher.floodgap.com.
+// - curl localhost:8080/gstats # Retrieve the "gstats" segment.
+// - curl localhost:8080/gstats?use_proxy=1 # Retrieve the "gstats" segment using the configured proxy.
+export default {
+  async fetch(req, env) {
+    const gopherAddr = "gopher.floodgap.com:70";
+
+    const url = new URL(req.url);
+    const useProxy = url.searchParams.has("use_proxy");
+
+    try {
+      const socket = useProxy ? env.proxy.connect(gopherAddr) : connect(gopherAddr);
+
+      // Write data to the socket. Specifically the "selector" followed by CR+LF.
+      const writer = socket.writable.getWriter()
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode(url.pathname + "\r\n");
+      await writer.write(encoded);
+
+      // The Gopher server should now return a response to us and close the connection.
+      // So start reading from the socket.
+      const reader = socket.readable.getReader();
+      const decoder = new TextDecoder();
+
+      let gopherResponse = "";
+      while (true) {
+        const res = await reader.read();
+        if (res.done) {
+          console.log("Stream done, socket connection has been closed.");
+          // TODO(soon): Half-open connections:
+          // see https://github.com/cloudflare/workerd/pull/162#discussion_r1020483277.
+          break;
+        }
+        gopherResponse += decoder.decode(res.value);
+      }
+
+      console.log("Read ", gopherResponse.length, " from Gopher server");
+
+      return new Response(gopherResponse, { headers: { "Content-Type": "text/plain" } });
+    } catch (error) {
+      return new Response("Socket connection failed: " + error, { status: 500 });
+    }
+  }
+};

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -570,4 +570,9 @@ jsg::Promise<jsg::Ref<Response>> ServiceWorkerGlobalScope::fetch(
   return fetchImpl(js, nullptr, kj::mv(requestOrUrl), kj::mv(requestInit), featureFlags);
 }
 
+jsg::Ref<Socket> ServiceWorkerGlobalScope::connect(
+    jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options) {
+  return connectImpl(js, nullptr, kj::mv(address));
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -19,6 +19,7 @@
 #include "trace.h"
 #include "scheduled.h"
 #include "blob.h"
+#include "sockets.h"
 
 namespace workerd::api {
 
@@ -272,6 +273,9 @@ public:
       jsg::Optional<Request::Initializer> requestInitr,
       CompatibilityFlags::Reader featureFlags);
 
+  jsg::Ref<Socket> connect(
+      jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options);
+
   jsg::Ref<ServiceWorkerGlobalScope> getSelf() {
     return JSG_THIS;
   }
@@ -413,6 +417,7 @@ public:
     JSG_NESTED_TYPE(FixedLengthStream);
     JSG_NESTED_TYPE(IdentityTransformStream);
     JSG_NESTED_TYPE(HTMLRewriter);
+    JSG_METHOD(connect);
 
     JSG_TS_ROOT();
     JSG_TS_DEFINE(

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1807,6 +1807,11 @@ jsg::Promise<jsg::Ref<Response>> fetchImpl(
   }
 }
 
+jsg::Ref<Socket> Fetcher::connect(
+    jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options) {
+  return connectImpl(js, JSG_THIS, kj::mv(address));
+}
+
 jsg::Promise<jsg::Ref<Response>> Fetcher::fetch(
     jsg::Lock& js, kj::OneOf<jsg::Ref<Request>, kj::String> requestOrUrl,
     jsg::Optional<kj::OneOf<RequestInitializerDict, jsg::Ref<Request>>> requestInit,

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -345,6 +345,9 @@ class Request;
 class Response;
 struct RequestInitializerDict;
 
+class Socket;
+struct SocketOptions;
+
 class Fetcher: public jsg::Object {
   // A capability to send HTTP requests to some destination other than the public internet.
   // This is the type of `request.fetcher` (if it is not null).
@@ -402,6 +405,9 @@ public:
   // Wraps kj::Url::parse to take into account whether the Fetcher requires a host to be
   // specified on URLs, Fetcher-specific URL decoding options, and error handling.
 
+  jsg::Ref<Socket> connect(
+      jsg::Lock& js, kj::String address, jsg::Optional<SocketOptions> options);
+
   jsg::Promise<jsg::Ref<Response>> fetch(
       jsg::Lock& js, kj::OneOf<jsg::Ref<Request>, kj::String> requestOrUrl,
       jsg::Optional<kj::OneOf<RequestInitializerDict, jsg::Ref<Request>>> requestInit,
@@ -432,6 +438,7 @@ public:
 
   JSG_RESOURCE_TYPE(Fetcher) {
     JSG_METHOD(fetch);
+    JSG_METHOD(connect);
 
     JSG_METHOD(get);
     JSG_METHOD(put);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -651,9 +651,10 @@ public:
       JSG_READONLY_PROTOTYPE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_PROTOTYPE_PROPERTY(cache, getCache);
 
-      JSG_TS_OVERRIDE({
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
         constructor(input: RequestInfo, init?: RequestInit);
-        get cf(): IncomingRequestCfProperties | undefined;
+        clone(): Request<CfHostMetadata>;
+        get cf(): IncomingRequestCfProperties<CfHostMetadata> | undefined;
       });
       // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
       // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.
@@ -672,9 +673,10 @@ public:
       JSG_READONLY_INSTANCE_PROPERTY(integrity, getIntegrity);
       JSG_READONLY_INSTANCE_PROPERTY(cache, getCache);
 
-      JSG_TS_OVERRIDE({
+      JSG_TS_OVERRIDE(<CfHostMetadata = unknown> {
         constructor(input: RequestInfo, init?: RequestInit);
-        readonly cf?: IncomingRequestCfProperties;
+        clone(): Request<CfHostMetadata>;
+        readonly cf?: IncomingRequestCfProperties<CfHostMetadata>;
       });
       // Use `RequestInfo` and `RequestInit` type aliases in constructor instead of inlining.
       // `IncomingRequestCfProperties` is defined in `/types/defines/cf.d.ts`.

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -1,0 +1,229 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sockets.h"
+#include "system-streams.h"
+
+
+namespace workerd::api {
+
+
+class TCPConnectResponseImpl final: public kj::HttpService::ConnectResponse, public kj::Refcounted {
+public:
+  TCPConnectResponseImpl(kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectResponse>> fulfiller)
+      : fulfiller(kj::mv(fulfiller)) {}
+
+  void setPromise(kj::Promise<void> promise) {
+    task = promise.eagerlyEvaluate([this](kj::Exception&& exception) {
+      if (fulfiller->isWaiting()) {
+        fulfiller->reject(kj::mv(exception));
+      } else {
+        kj::throwRecoverableException(kj::mv(exception));
+      }
+    });
+  }
+
+  kj::Own<kj::AsyncIoStream> accept(
+      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    KJ_REQUIRE(statusCode >= 200 && statusCode < 300, "the statusCode must be 2xx for accept");
+
+    auto headersCopy = kj::heap(headers.clone());
+
+    auto pipe = kj::newTwoWayPipe();
+
+    fulfiller->fulfill(kj::HttpClient::ConnectResponse {
+      statusCode,
+      statusText,
+      headersCopy.get(),
+      pipe.ends[0].attach(kj::addRef(*this)),
+    });
+    return kj::mv(pipe.ends[1]);
+  }
+
+  kj::Own<kj::AsyncOutputStream> reject(
+      uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    KJ_REQUIRE(statusCode < 200 || statusCode >= 300, "the statusCode must not be 2xx for reject.");
+    kj::throwRecoverableException(KJ_EXCEPTION(FAILED,
+        kj::str("jsg.Error: Connection rejected by proxy with HTTP code ", statusCode)));
+    KJ_UNREACHABLE;
+  }
+
+private:
+  kj::Own<kj::PromiseFulfiller<kj::HttpClient::ConnectResponse>> fulfiller;
+  kj::Promise<void> task = nullptr;
+};
+
+jsg::Ref<Socket> connectImplNoOutputLock(
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, kj::String address) {
+  auto& ioContext = IoContext::current();
+
+  auto jsRequest = Request::constructor(js, kj::str(address), nullptr);
+  kj::Own<WorkerInterface> client = fetcher->getClient(
+      ioContext, jsRequest->serializeCfBlobJson(js), "connect"_kj);
+
+  // TODO: Validate `address` is well formed. Do I need to use `parseAddress` here or is there
+  // a better way?
+
+  // Set up the connection. This is similar to HttpClientAdapter::connect.
+  auto headers = kj::heap<kj::HttpHeaders>(ioContext.getHeaderTable());
+  auto paf = kj::newPromiseAndFulfiller<kj::HttpClient::ConnectResponse>();
+  auto tunnel = kj::refcounted<TCPConnectResponseImpl>(kj::mv(paf.fulfiller));
+  auto promise = client->connect(address, *headers, *tunnel)
+      .attach(kj::str(address), kj::mv(headers));
+  tunnel->setPromise(kj::mv(promise));
+  kj::Promise<kj::HttpClient::ConnectResponse> connResponse = paf.promise.attach(kj::mv(tunnel));
+  return jsg::alloc<Socket>(kj::mv(connResponse));
+}
+
+jsg::Ref<Socket> connectImpl(
+    jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, kj::String address) {
+  jsg::Ref<Fetcher> actualFetcher = nullptr;
+  KJ_IF_MAYBE(f, fetcher) {
+    actualFetcher = kj::mv(*f);
+  } else {
+    actualFetcher = jsg::alloc<Fetcher>(
+        IoContext::NULL_CLIENT_CHANNEL, Fetcher::RequiresHostAndProtocol::YES);
+  }
+  return connectImplNoOutputLock(js, kj::mv(actualFetcher), kj::mv(address));
+}
+
+kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection(
+    kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) {
+  return connectionPromise.then([](kj::HttpClient::ConnectResponse&& response)
+      -> kj::Own<kj::AsyncIoStream> {
+    KJ_REQUIRE(response.statusCode >= 200 && response.statusCode < 300,
+        "the statusCode must be 2xx for connect");
+    KJ_SWITCH_ONEOF(response.connectionOrBody) {
+      KJ_CASE_ONEOF(connection, kj::Own<kj::AsyncIoStream>) {
+        return kj::mv(connection);
+      }
+      KJ_CASE_ONEOF(body, kj::Own<kj::AsyncInputStream>) {
+        kj::throwRecoverableException(
+            KJ_EXCEPTION(FAILED, "jsg.Error: Could not establish proxy connection"));
+      }
+    }
+    KJ_UNREACHABLE;
+  });
+}
+
+InitData initialiseSocket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) {
+  auto& context = IoContext::current();
+
+  // Initialise the readable/writable streams with a custom AsyncIoStream that waits for the
+  // completion of `connectionPromise` before performing reads/writes.
+  auto stream = kj::refcounted<PipelinedAsyncIoStream>(processConnection(kj::mv(connectionPromise)));
+  auto sysStreams = newSystemMultiStream(kj::addRef(*stream), StreamEncoding::IDENTITY, context);
+
+  return {
+    .readable = jsg::alloc<ReadableStream>(context, kj::mv(sysStreams.readable)),
+    .writable = jsg::alloc<WritableStream>(context, kj::mv(sysStreams.writable)),
+    .closeFulfiller = IoContext::current().addObject(
+        kj::heap<kj::PromiseFulfillerPair<void>>(kj::newPromiseAndFulfiller<void>()))
+  };
+}
+
+Socket::Socket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise) :
+    Socket(initialiseSocket(kj::mv(connectionPromise))) {};
+
+jsg::Promise<void> Socket::close(jsg::Lock& js) {
+  if (!closeFulfiller->fulfiller->isWaiting()) {
+    return js.resolvedPromise();
+  }
+
+  auto result = js.resolvedPromise();
+  result = readable->cancel(js, nullptr);
+  result = writable->abort(js, nullptr);
+  closeFulfiller->fulfiller->fulfill();
+  return result;
+}
+
+PipelinedAsyncIoStream::PipelinedAsyncIoStream(kj::Promise<kj::Own<kj::AsyncIoStream>> inner) :
+    inner(kj::mv(inner)) {};
+
+void PipelinedAsyncIoStream::shutdownWrite() {
+  thenOrRunNow<void>([](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->shutdownWrite();
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+void PipelinedAsyncIoStream::abortRead() {
+  thenOrRunNow<void>([](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->abortRead();
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+void PipelinedAsyncIoStream::getsockopt(int level, int option, void* value, uint* length) {
+  thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->getsockopt(level, option, value, length);
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+void PipelinedAsyncIoStream::setsockopt(int level, int option, const void* value, uint length) {
+  thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->setsockopt(level, option, value, length);
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+void PipelinedAsyncIoStream::getsockname(struct sockaddr* addr, uint* length) {
+  thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->getsockname(addr, length);
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+void PipelinedAsyncIoStream::getpeername(struct sockaddr* addr, uint* length) {
+  thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    (*stream)->getpeername(addr, length);
+    return kj::READY_NOW;
+  }).detach([this](kj::Exception&& exception) mutable {
+    error = kj::mv(exception);
+  });
+}
+
+kj::Promise<size_t> PipelinedAsyncIoStream::read(void* buffer, size_t minBytes, size_t maxBytes) {
+  return thenOrRunNow<size_t>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    return (*stream)->read(buffer, minBytes, maxBytes);
+  });
+}
+
+kj::Promise<size_t> PipelinedAsyncIoStream::tryRead(void* buffer, size_t minBytes, size_t maxBytes) {
+  return thenOrRunNow<size_t>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    return (*stream)->tryRead(buffer, minBytes, maxBytes);
+  });
+}
+
+kj::Promise<void> PipelinedAsyncIoStream::write(const void* buffer, size_t size) {
+  return thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    return (*stream)->write(buffer, size);
+  });
+}
+
+kj::Promise<void> PipelinedAsyncIoStream::write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) {
+  return thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    return (*stream)->write(pieces);
+  });
+}
+
+kj::Promise<void> PipelinedAsyncIoStream::whenWriteDisconnected() {
+  return thenOrRunNow<void>([=](kj::Own<kj::AsyncIoStream>* stream) {
+    return (*stream)->whenWriteDisconnected();
+  });
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -1,0 +1,124 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+#include "http.h"
+
+
+namespace workerd::api {
+
+class PipelinedAsyncIoStream final : public kj::AsyncIoStream, public kj::Refcounted {
+  // A stream that is backed by a promise for an AsyncIoStream. All operations on this stream
+  // are deferred until the `inner` promise completes.
+public:
+  explicit PipelinedAsyncIoStream(kj::Promise<kj::Own<kj::AsyncIoStream>> inner);
+  void shutdownWrite() override;
+  void abortRead() override;
+  void getsockopt(int level, int option, void* value, uint* length) override;
+  void setsockopt(int level, int option, const void* value, uint length) override;
+
+  void getsockname(struct sockaddr* addr, uint* length) override;
+  void getpeername(struct sockaddr* addr, uint* length) override;
+
+  // AsyncInputStream methods:
+  kj::Promise<size_t> read(void* buffer, size_t minBytes, size_t maxBytes) override;
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override;
+
+  // AsyncOutputStream methods:
+  kj::Promise<void> write(const void* buffer, size_t size) override;
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override;
+
+  kj::Promise<void> whenWriteDisconnected() override;
+
+private:
+  template <typename T>
+  kj::Promise<T> thenOrRunNow(std::function<kj::Promise<T> (kj::Own<kj::AsyncIoStream> *)> f) {
+    // Either calls `then` on the `inner` promise with the `f` callback, or calls `f` on an already
+    // stored stream (if the `inner` promise completed).
+    KJ_IF_MAYBE(e, error) {
+      kj::throwRecoverableException(kj::mv(*e));
+    }
+
+    KJ_IF_MAYBE(s, completedInner) {
+      return f(s);
+    } else {
+      return inner.then([this, f](kj::Own<kj::AsyncIoStream> stream) -> kj::Promise<T> {
+        completedInner = kj::mv(stream);
+        return f(&KJ_ASSERT_NONNULL(completedInner));
+      });
+    }
+  }
+
+  kj::Maybe<kj::Own<kj::AsyncIoStream>> completedInner;
+  // Stored io stream once the `inner` promise completes.
+  kj::Maybe<kj::Exception> error;
+  // Stored error if any of the operations throw.
+  kj::Promise<kj::Own<kj::AsyncIoStream>> inner;
+  // A promise holding a stream that will be available at some point in the future. Typically once
+  // a connection is established.
+};
+
+struct SocketOptions {
+  bool tsl; // TODO(later): TCP socket options need to be implemented.
+  JSG_STRUCT(tsl);
+};
+
+struct InitData {
+  jsg::Ref<ReadableStream> readable;
+  jsg::Ref<WritableStream> writable;
+  IoOwn<kj::PromiseFulfillerPair<void>> closeFulfiller;
+};
+
+class Socket: public jsg::Object {
+public:
+  Socket(InitData data)
+      : readable(kj::mv(data.readable)), writable(kj::mv(data.writable)),
+        closeFulfiller(kj::mv(data.closeFulfiller)) {};
+  Socket(kj::Promise<kj::HttpClient::ConnectResponse> connectionPromise);
+
+  jsg::Ref<ReadableStream> getReadable() { return readable.addRef(); }
+  jsg::Ref<WritableStream> getWritable() { return writable.addRef(); }
+  jsg::Promise<void> getClosed() {
+    // TODO: Right now this promise won't complete when the remote end closes the socket.
+    //       Do we need to wrap ReadableStream/WritableStream to make this work or is there a
+    //       better way?
+    auto& context = IoContext::current();
+    return context.awaitIo(kj::mv(closeFulfiller->promise));
+  }
+
+  jsg::Promise<void> close(jsg::Lock& js);
+  // Closes the socket connection.
+
+  JSG_RESOURCE_TYPE(Socket, CompatibilityFlags::Reader flags) {
+    JSG_READONLY_INSTANCE_PROPERTY(readable, getReadable);
+    JSG_READONLY_INSTANCE_PROPERTY(writable, getWritable);
+    JSG_READONLY_INSTANCE_PROPERTY(closed, getClosed);
+    JSG_METHOD(close);
+  }
+
+private:
+  jsg::Ref<ReadableStream> readable;
+  jsg::Ref<WritableStream> writable;
+  kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection();
+  IoOwn<kj::PromiseFulfillerPair<void>> closeFulfiller;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(readable, writable);
+  }
+};
+
+jsg::Ref<Socket> connectImplNoOutputLock(
+    jsg::Lock& js, jsg::Ref<Fetcher> fetcher, kj::String address);
+
+jsg::Ref<Socket> connectImpl(
+    jsg::Lock& js, kj::Maybe<jsg::Ref<Fetcher>> fetcher, kj::String address);
+
+#define EW_SOCKETS_ISOLATE_TYPES         \
+  api::Socket,                       \
+  api::SocketOptions
+
+// The list of sockets.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
+}  // namespace workerd::api

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -297,20 +297,41 @@ public:
 
     JSG_ASYNC_ITERABLE(values);
 
-    JSG_TS_DEFINE(interface ReadableStream<R = any> {
-      cancel(reason?: any): Promise<void>;
+    if (flags.getJsgPropertyOnPrototypeTemplate()) {
+      JSG_TS_DEFINE(interface ReadableStream<R = any> {
+        get locked(): boolean;
 
-      getReader(): ReadableStreamDefaultReader<R>;
-      getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+        cancel(reason?: any): Promise<void>;
 
-      pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-      pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+        getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
 
-      tee(): [ReadableStream<R>, ReadableStream<R>];
+        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
 
-      values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-      [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-    });
+        tee(): [ReadableStream<R>, ReadableStream<R>];
+
+        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+      });
+    } else {
+      JSG_TS_DEFINE(interface ReadableStream<R = any> {
+        readonly locked: boolean;
+
+        cancel(reason?: any): Promise<void>;
+
+        getReader(): ReadableStreamDefaultReader<R>;
+        getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+
+        pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+        pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+
+        tee(): [ReadableStream<R>, ReadableStream<R>];
+
+        values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+        [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+      });
+    }
     JSG_TS_OVERRIDE(const ReadableStream: {
       prototype: ReadableStream;
       new (underlyingSource: UnderlyingByteSource, strategy?: QueuingStrategy<Uint8Array>): ReadableStream<Uint8Array>;

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -252,6 +252,14 @@ kj::Own<WritableStreamSink> newSystemStream(
   return kj::heap<EncodedAsyncOutputStream>(kj::mv(inner), encoding, context);
 }
 
+SystemMultiStream newSystemMultiStream(
+    kj::Own<PipelinedAsyncIoStream> rc, StreamEncoding encoding, IoContext& context) {
+  return {
+    .readable = kj::heap<EncodedAsyncInputStream>(kj::addRef(*rc), encoding, context),
+    .writable = kj::heap<EncodedAsyncOutputStream>(kj::mv(rc), encoding, context)
+  };
+}
+
 StreamEncoding getContentEncoding(IoContext& context, const kj::HttpHeaders& headers,
                                   Response::BodyEncoding bodyEncoding) {
   if (bodyEncoding == Response::BodyEncoding::MANUAL) {

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -8,6 +8,7 @@
 
 #include "streams.h"
 #include "http.h"
+#include "sockets.h"
 #include <workerd/io/io-context.h>
 
 namespace workerd::api {
@@ -30,6 +31,18 @@ kj::Own<WritableStreamSink> newSystemStream(
 // A WritableStreamSink which automatically encodes its underlying stream.
 //
 // NOTE: As with the other overload of newSystemStream(), `inner` must be wholly owned.
+
+struct SystemMultiStream {
+  kj::Own<ReadableStreamSource> readable;
+  kj::Own<WritableStreamSink> writable;
+};
+
+SystemMultiStream newSystemMultiStream(
+    kj::Own<PipelinedAsyncIoStream> rc, StreamEncoding encoding,
+    IoContext& context = IoContext::current());
+// A combo ReadableStreamSource and WritableStreamSink which automatically decodes/encodes its
+// underlying stream. This function takes `PipelinedAsyncIoStream` because it needs a refcounted
+// stream.
 
 StreamEncoding getContentEncoding(IoContext& context, const kj::HttpHeaders& headers,
                                   Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO);

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -38,6 +38,9 @@ kj::Maybe<TraceItem::EventInfo> TraceItem::getEvent() {
       KJ_CASE_ONEOF(alarm, Trace::AlarmEventInfo) {
         return kj::Maybe(jsg::alloc<AlarmEventInfo>(kj::addRef(*trace), alarm));
       }
+      KJ_CASE_ONEOF(custom, Trace::CustomEventInfo) {
+        return kj::Maybe(jsg::alloc<CustomEventInfo>(kj::addRef(*trace), custom));
+      }
     }
   }
   return nullptr;
@@ -170,6 +173,9 @@ TraceItem::AlarmEventInfo::AlarmEventInfo(kj::Own<Trace> trace,
 kj::Date TraceItem::AlarmEventInfo::getScheduledTime() {
   return eventInfo.scheduledTime;
 }
+
+TraceItem::CustomEventInfo::CustomEventInfo(kj::Own<Trace> trace,
+    const Trace::CustomEventInfo& eventInfo) : trace(kj::mv(trace)), eventInfo(eventInfo) {}
 
 kj::Maybe<kj::StringPtr> TraceItem::getScriptName() {
   return trace->scriptName;

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -50,10 +50,12 @@ public:
   class FetchEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
+  class CustomEventInfo;
 
   explicit TraceItem(kj::Own<Trace> trace);
 
-  typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>, jsg::Ref<AlarmEventInfo>> EventInfo;
+  typedef kj::OneOf<jsg::Ref<FetchEventInfo>, jsg::Ref<ScheduledEventInfo>,
+      jsg::Ref<AlarmEventInfo>, jsg::Ref<CustomEventInfo>> EventInfo;
   kj::Maybe<EventInfo> getEvent();
   // TODO(someday): support more event types (trace, queue) via kj::OneOf.
   kj::Maybe<double> getEventTimestamp();
@@ -186,6 +188,17 @@ private:
   const Trace::AlarmEventInfo& eventInfo;
 };
 
+class TraceItem::CustomEventInfo final: public jsg::Object {
+public:
+  explicit CustomEventInfo(kj::Own<Trace> trace, const Trace::CustomEventInfo& eventInfo);
+
+  JSG_RESOURCE_TYPE(CustomEventInfo) {}
+
+private:
+  kj::Own<Trace> trace;
+  const Trace::CustomEventInfo& eventInfo;
+};
+
 class TraceLog final: public jsg::Object {
 public:
   TraceLog(kj::Own<Trace> trace, const Trace::Log& log);
@@ -283,6 +296,7 @@ private:
   api::TraceEvent,                            \
   api::TraceItem,                             \
   api::TraceItem::AlarmEventInfo,             \
+  api::TraceItem::CustomEventInfo,            \
   api::TraceItem::ScheduledEventInfo,         \
   api::TraceItem::FetchEventInfo,             \
   api::TraceItem::FetchEventInfo::Request,    \

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -808,8 +808,8 @@ size_t IoContext::getTimeoutCount() {
   return timeoutManager->getTimeoutCount();
 }
 
-kj::Date IoContext::now() {
-  kj::Date adjustedTime = getIoChannelFactory().getTimer().now();
+kj::Date IoContext::now(IncomingRequest& incomingRequest) {
+  kj::Date adjustedTime = incomingRequest.ioChannelFactory->getTimer().now();
 
   KJ_IF_MAYBE (maybeNextTimeout, timeoutManager->getNextTimeout()) {
     // Don't return a time beyond when the next setTimeout() callback is intended to run. This
@@ -820,6 +820,10 @@ kj::Date IoContext::now() {
   } else {
     return adjustedTime;
   }
+}
+
+kj::Date IoContext::now() {
+  return now(getCurrentIncomingRequest());
 }
 
 kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -685,6 +685,7 @@ public:
 
   size_t getTimeoutCount();
 
+  kj::Date now(IncomingRequest& incomingRequest);
   kj::Date now();
   // Access the event loop's current time point. This will remain constant between ticks.
 

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -152,6 +152,9 @@ void Trace::copyTo(rpc::Trace::Builder builder) {
         auto alarmBuilder = eventInfoBuilder.initAlarm();
         alarm.copyTo(alarmBuilder);
       }
+      KJ_CASE_ONEOF(custom, CustomEventInfo) {
+        eventInfoBuilder.initCustom();
+      }
     }
   } else {
     eventInfoBuilder.setNone();
@@ -214,6 +217,9 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
         break;
       case rpc::Trace::EventInfo::Which::ALARM:
         eventInfo = AlarmEventInfo(e.getAlarm());
+        break;
+      case rpc::Trace::EventInfo::Which::CUSTOM:
+        eventInfo = CustomEventInfo(e.getCustom());
         break;
       case rpc::Trace::EventInfo::Which::NONE:
         eventInfo = nullptr;
@@ -426,6 +432,7 @@ void WorkerTracer::setEventInfo(kj::Date timestamp, Trace::EventInfo&& info) {
     }
     KJ_CASE_ONEOF(_, Trace::ScheduledEventInfo) {}
     KJ_CASE_ONEOF(_, Trace::AlarmEventInfo) {}
+    KJ_CASE_ONEOF(_, Trace::CustomEventInfo) {}
   }
   trace->bytesUsed = newSize;
   trace->eventInfo = kj::mv(info);

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -98,6 +98,13 @@ public:
     void copyTo(rpc::Trace::AlarmEventInfo::Builder builder);
   };
 
+  class CustomEventInfo {
+  public:
+    explicit CustomEventInfo() {};
+    CustomEventInfo(rpc::Trace::CustomEventInfo::Reader reader) {};
+
+  };
+
   class FetchResponseInfo {
   public:
     explicit FetchResponseInfo(uint16_t statusCode);
@@ -150,7 +157,7 @@ public:
   kj::Date eventTimestamp = kj::UNIX_EPOCH;
   // We treat the origin value as "unset".
 
-  typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo> EventInfo;
+  typedef kj::OneOf<FetchEventInfo, ScheduledEventInfo, AlarmEventInfo, CustomEventInfo> EventInfo;
   kj::Maybe<EventInfo> eventInfo;
   // TODO(someday): Support more event types.
   // TODO(someday): Work out what sort of information we may want to convey about the parent

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -405,7 +405,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
 
   auto& context = incomingRequest->getContext();
   KJ_IF_MAYBE(t, incomingRequest->getWorkerTracer()) {
-      t->setEventInfo(context.now(), Trace::CustomEventInfo());
+      t->setEventInfo(context.now(*incomingRequest), Trace::CustomEventInfo());
   }
 
   return event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -402,6 +402,12 @@ kj::Promise<WorkerInterface::CustomEvent::Result>
   auto incomingRequest = kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest,
                                 "customEvent() can only be called once"));
   this->incomingRequest = nullptr;
+
+  auto& context = incomingRequest->getContext();
+  KJ_IF_MAYBE(t, incomingRequest->getWorkerTracer()) {
+      t->setEventInfo(context.now(), Trace::CustomEventInfo());
+  }
+
   return event->run(kj::mv(incomingRequest), entrypointName).attach(kj::mv(event));
 }
 

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -45,6 +45,7 @@ struct Trace @0x8e8d911203762d34 {
     fetch @6 :FetchEventInfo;
     scheduled @7 :ScheduledEventInfo;
     alarm @9 :AlarmEventInfo;
+    custom @13 :CustomEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -66,6 +67,8 @@ struct Trace @0x8e8d911203762d34 {
   struct AlarmEventInfo {
     scheduledTimeMs @0 :Int64;
   }
+
+  struct CustomEventInfo {}
 
   response @8 :FetchResponseInfo;
   struct FetchResponseInfo {

--- a/src/workerd/jsg/dom-exception.c++
+++ b/src/workerd/jsg/dom-exception.c++
@@ -8,28 +8,23 @@
 
 namespace workerd::jsg {
 
-Ref<DOMException> DOMException::constructor(Optional<v8::Global<v8::String>> message,
-                                               Optional<kj::String> name, v8::Isolate* isolate) {
-  v8::Global<v8::String> errMessage;
-  KJ_IF_MAYBE(m, message) {
-    errMessage = kj::mv(*m);
-  } else {
-    errMessage = v8::Global<v8::String>(isolate, v8::String::Empty(isolate));
-  }
-  auto errorForStack = v8::Exception::Error(errMessage.Get(isolate)).As<v8::Object>();
-  return jsg::alloc<DOMException>(kj::mv(errMessage), kj::mv(name),
-                                  v8::Global<v8::Object>(isolate, errorForStack));
+Ref<DOMException> DOMException::constructor(
+    Lock& js,
+    Optional<kj::String> message,
+    Optional<kj::String> name) {
+  kj::String errMessage = kj::mv(message).orDefault([&] { return kj::String(); });
+  return jsg::alloc<DOMException>(
+      kj::mv(errMessage),
+      kj::mv(name).orDefault([] { return kj::str("Error"); }),
+      js.v8Ref(v8::Exception::Error(v8Str(js.v8Isolate, errMessage)).As<v8::Object>()));
 }
 
-kj::String DOMException::getName() {
-  KJ_IF_MAYBE(n, name) {
-    return kj::str(*n);
-  }
-  return kj::str("Error");
+kj::StringPtr DOMException::getName() {
+  return name;
 }
 
-v8::Local<v8::String> DOMException::getMessage(v8::Isolate* isolate) {
-  return message.Get(isolate);
+kj::StringPtr DOMException::getMessage() {
+  return message;
 }
 
 int DOMException::getCode() {
@@ -38,18 +33,21 @@ int DOMException::getCode() {
     JSG_DOM_EXCEPTION_FOR_EACH_ERROR_NAME(MAP_ENTRY)
 #undef MAP_ENTRY
   };
-  KJ_IF_MAYBE(n, name) {
-    auto code = legacyCodes.find(*n);
-    if (code != legacyCodes.end()) {
-      return code->second;
-    }
+  auto code = legacyCodes.find(name);
+  if (code != legacyCodes.end()) {
+    return code->second;
   }
   return 0;
 }
 
-v8::Local<v8::Value> DOMException::getStack(v8::Isolate* isolate) {
-  auto stackString = v8Str(isolate, "stack", v8::NewStringType::kInternalized);
-  return check(errorForStack.Get(isolate)->Get(isolate->GetCurrentContext(), stackString));
+v8::Local<v8::Value> DOMException::getStack(Lock& js) {
+  return check(errorForStack.getHandle(js)->Get(
+      js.v8Isolate->GetCurrentContext(),
+      v8StrIntern(js.v8Isolate, "stack")));
+}
+
+void DOMException::visitForGc(GcVisitor& visitor) {
+  visitor.visit(errorForStack);
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1298,15 +1298,14 @@ public:
     // we need to drop down to the C++ interface and generate the kj::Exception
     // ourselves. If any additional JSG_RESOURCE_TYPE error-like things are
     // introduced, they'll need to be handled explicitly here also.
-    auto isolate = context->GetIsolate();
-    auto& wrapper = TypeWrapper::from(isolate);
+    auto& js = Lock::from(context->GetIsolate());
+    auto& wrapper = TypeWrapper::from(js.v8Isolate);
     KJ_IF_MAYBE(domException, wrapper.tryUnwrap(context, handle,
                                                 (DOMException*)nullptr,
                                                 parentObject)) {
-      auto isolate = context->GetIsolate();
       return KJ_EXCEPTION(FAILED,
           kj::str("jsg.DOMException(", domException->getName(), "): ",
-                  domException->getMessage(isolate)));
+                  domException->getMessage()));
     } else {
 
       static const constexpr kj::StringPtr PREFIXES[] = {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -539,6 +539,11 @@ private:
       }
     }
 
+    kj::Promise<void> connect(
+        kj::StringPtr host, const kj::HttpHeaders& headers, ConnectResponse& tunnel) override {
+      return parent.serviceAdapter->connect(host, headers, tunnel);
+    }
+
     void prewarm(kj::StringPtr url) override {}
     kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
       throwUnsupported();
@@ -648,6 +653,15 @@ public:
 
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
     return { this, kj::NullDisposer::instance };
+  }
+
+  kj::Promise<void> connect(
+      kj::StringPtr host, const kj::HttpHeaders& headers, ConnectResponse& tunnel) override {
+    // This code is hit when the global `connect` function is called in a JS worker script.
+    // It represents a proxy-less TCP connection, which means we can simply defer the handling of
+    // the connection to the service adapter (likely NetworkHttpClient). Its behaviour will be to
+    // connect directly to the host over TCP.
+    return serviceAdapter->connect(host, headers, tunnel);
   }
 
 private:

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -15,6 +15,7 @@
 #include <workerd/api/global-scope.h>
 #include <workerd/api/kv.h>
 #include <workerd/api/r2-admin.h>
+#include <workerd/api/sockets.h>
 #include <workerd/api/urlpattern.h>
 #include <workerd/util/thread-scopes.h>
 #include <openssl/sha.h>
@@ -50,6 +51,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
   EW_FORMDATA_ISOLATE_TYPES,
   EW_HTML_REWRITER_ISOLATE_TYPES,
   EW_HTTP_ISOLATE_TYPES,
+  EW_SOCKETS_ISOLATE_TYPES,
   EW_KV_ISOLATE_TYPES,
   EW_R2_PUBLIC_BETA_ADMIN_ISOLATE_TYPES,
   EW_R2_PUBLIC_BETA_ISOLATE_TYPES,

--- a/src/workerd/tools/api-encoder.c++
+++ b/src/workerd/tools/api-encoder.c++
@@ -40,7 +40,8 @@
   F("url", EW_URL_ISOLATE_TYPES)                                               \
   F("url-standard", EW_URL_STANDARD_ISOLATE_TYPES)                             \
   F("url-pattern", EW_URLPATTERN_ISOLATE_TYPES)                                \
-  F("websocket", EW_WEBSOCKET_ISOLATE_TYPES)
+  F("websocket", EW_WEBSOCKET_ISOLATE_TYPES)                                   \
+  F("sockets", EW_SOCKETS_ISOLATE_TYPES)
 
 namespace workerd::api {
 namespace {


### PR DESCRIPTION
- Add missing `locked` property to `ReadableStream` define
- Allow the `HostMetadata` type parameter on `IncomingRequestCfProperties` to be specified with `Request`